### PR TITLE
chore(frontend): add Vercel deploy config

### DIFF
--- a/frontend/.vercelignore
+++ b/frontend/.vercelignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+dist-ssr
+.env
+.env.*
+!.env.example
+Dockerfile
+nginx.conf
+*.log
+.DS_Store

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Vercel deployment configuration for the React frontend so it can be hosted free on Vercel's Hobby plan while the Python backend continues to run locally on the Mac mini (the frontend talks directly to Supabase, not the Python service).

- `frontend/vercel.json`: Vite framework preset, SPA rewrites (`/(.*) → /index.html`) so React Router routes like `/subscriptions/new` work on direct visits/refresh, and 1-year immutable `Cache-Control` for hashed `/assets/*`.
- `frontend/.vercelignore`: excludes `Dockerfile`, `nginx.conf`, `node_modules`, `dist`, and local `.env*` from Vercel uploads.

## Deploy steps (one-time, after merge)

1. Import repo at https://vercel.com/new and **set Root Directory to `frontend`** (monorepo: repo root is the Python project).
2. Framework should auto-detect as **Vite**.
3. Add Project env vars (Production + Preview):
   - `VITE_SUPABASE_URL`
   - `VITE_SUPABASE_ANON_KEY`
4. After first deploy, add the Vercel URL to Supabase Auth → URL Configuration → Redirect URLs.

## Test plan

- [x] `npm run build` succeeds locally (433 KB JS / 126 KB gzip)
- [ ] First Vercel deploy succeeds with Root Directory = `frontend`
- [ ] Direct-visiting `/subscriptions/new` on the deployed URL loads the page (verifies SPA rewrite)
- [ ] Google SSO flow completes end-to-end on the deployed URL
- [ ] Creating/editing a subscription persists to Supabase from the deployed frontend

Made with [Cursor](https://cursor.com)