### PR TITLE
Add interactive map for subscription bounding box

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Environment
 .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@geoman-io/leaflet-geoman-free": "^2.19.3",
         "@supabase/supabase-js": "^2.104.1",
         "leaflet": "^1.9.4",
         "react": "^19.2.5",
@@ -447,6 +448,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@geoman-io/leaflet-geoman-free": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/@geoman-io/leaflet-geoman-free/-/leaflet-geoman-free-2.19.3.tgz",
+      "integrity": "sha512-HjbEpfAEUs0NyI1Dhvz3SMVG6m0pAN/1Eo0tRKsz9cpaROTrFtmJGY22swEir1Uj/8IeGF1NJId38C5Fu+nZGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-contains": "^7.3.3",
+        "@turf/kinks": "^7.3.3",
+        "@turf/line-intersect": "^7.3.3",
+        "@turf/line-split": "^7.3.3",
+        "lodash": "4.18.1",
+        "polyclip-ts": "^0.16.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.2.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -993,6 +1014,243 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.5.tgz",
+      "integrity": "sha512-P4JUAHgvJkD+8ybQ6d1OHp9TBsGsjJxF5lWeXJgp0k4+Hd/D0CVy4/mhLkZdNa6QdljVdwNcfU0CTqy1WsSQig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.5.tgz",
+      "integrity": "sha512-dPW8d4vs1v8WMobjyq/TVqajjPwkMsl94IF58yp1UYlmJDQrW4iNRUmI9fFzww+fl7epCKNwY+jZhXf1DRi93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1022,7 +1280,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1488,6 +1745,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2705,6 +2971,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2967,6 +3239,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -3171,6 +3462,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -3313,6 +3619,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -3433,6 +3745,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -3467,6 +3785,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -3546,6 +3873,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.104.1",
+        "leaflet": "^1.9.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.14.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -629,6 +632,17 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -1004,12 +1018,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.12.2",
@@ -2357,6 +2388,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3153,6 +3190,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,15 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.104.1",
+    "leaflet": "^1.9.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.14.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@geoman-io/leaflet-geoman-free": "^2.19.3",
     "@supabase/supabase-js": "^2.104.1",
     "leaflet": "^1.9.4",
     "react": "^19.2.5",

--- a/frontend/src/components/BoundingBoxMap.tsx
+++ b/frontend/src/components/BoundingBoxMap.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { MapContainer, TileLayer, Rectangle, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// Default Toronto box (matches the DB default for new subscriptions).
+const DEFAULT_BBOX = '43.640990267992834,-79.38644479872552,43.671784241717916,-79.38319149385921';
+
+interface ParsedBBox {
+  swLat: number;
+  swLng: number;
+  neLat: number;
+  neLng: number;
+}
+
+function parseBBox(value: string | undefined | null): ParsedBBox {
+  const fallback = DEFAULT_BBOX;
+  const parts = (value && value.split(',').length === 4 ? value : fallback)
+    .split(',')
+    .map((s) => Number(s.trim()));
+  if (parts.some((n) => !Number.isFinite(n))) {
+    return parseBBox(fallback);
+  }
+  // Normalize: ensure first pair is the SW corner, second is NE.
+  const [a, b, c, d] = parts;
+  return {
+    swLat: Math.min(a, c),
+    swLng: Math.min(b, d),
+    neLat: Math.max(a, c),
+    neLng: Math.max(b, d),
+  };
+}
+
+function formatBBox(b: ParsedBBox): string {
+  return `${b.swLat},${b.swLng},${b.neLat},${b.neLng}`;
+}
+
+/**
+ * Listens to the Leaflet map's move/zoom events and reports the
+ * current viewport bounds as a "lat_sw,lng_sw,lat_ne,lng_ne" string.
+ */
+function ViewportTracker({ onChange }: { onChange: (value: string) => void }) {
+  const map = useMap();
+  const lastReported = useRef<string>('');
+
+  useEffect(() => {
+    const report = () => {
+      const b = map.getBounds();
+      const next = formatBBox({
+        swLat: b.getSouth(),
+        swLng: b.getWest(),
+        neLat: b.getNorth(),
+        neLng: b.getEast(),
+      });
+      if (next !== lastReported.current) {
+        lastReported.current = next;
+        onChange(next);
+      }
+    };
+    // Initial report once the map has settled.
+    map.whenReady(report);
+    map.on('moveend', report);
+    map.on('zoomend', report);
+    return () => {
+      map.off('moveend', report);
+      map.off('zoomend', report);
+    };
+  }, [map, onChange]);
+
+  return null;
+}
+
+interface BoundingBoxMapProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function BoundingBoxMap({ value, onChange }: BoundingBoxMapProps) {
+  const initial = useMemo(() => parseBBox(value), [value]);
+  const initialBounds = useMemo<L.LatLngBoundsExpression>(
+    () => [
+      [initial.swLat, initial.swLng],
+      [initial.neLat, initial.neLng],
+    ],
+    [initial],
+  );
+
+  // Show a rectangle representing the saved value (kept in sync with `value`).
+  const currentBounds = useMemo<L.LatLngBoundsExpression>(() => {
+    const b = parseBBox(value);
+    return [
+      [b.swLat, b.swLng],
+      [b.neLat, b.neLng],
+    ];
+  }, [value]);
+
+  return (
+    <div>
+      <div className="h-72 w-full rounded-lg overflow-hidden border border-gray-300">
+        <MapContainer
+          bounds={initialBounds}
+          scrollWheelZoom
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <Rectangle
+            bounds={currentBounds}
+            pathOptions={{
+              color: '#2563eb',
+              weight: 2,
+              fillOpacity: 0.05,
+            }}
+          />
+          <ViewportTracker onChange={onChange} />
+        </MapContainer>
+      </div>
+      <p className="mt-2 text-xs text-gray-500 break-all font-mono">{value}</p>
+      <p className="mt-1 text-xs text-gray-400">
+        Pan and zoom — the visible area defines the search bounding box.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/BoundingBoxMap.tsx
+++ b/frontend/src/components/BoundingBoxMap.tsx
@@ -81,7 +81,29 @@ function RectangleEditor({
       dragMode: true,
       removalMode: false,
     });
-    map.pm.setLang('en');
+    // Override the default toolbar tooltips and the shared "Finish" action label
+    // so each mode reads naturally for our use case. setLang supports custom
+    // language names but the TS types restrict to built-in locales, so we cast.
+    (map.pm.setLang as unknown as (
+      name: string,
+      lang: Record<string, unknown>,
+      fallback: string,
+    ) => void)(
+      'rentalfinder',
+      {
+        buttonTitles: {
+          drawRectButton: 'Draw new search area',
+          editButton: 'Resize search area',
+          dragButton: 'Move search area',
+        },
+        actions: {
+          finish: 'Done',
+          cancel: 'Cancel',
+          finishMode: 'Done',
+        },
+      },
+      'en',
+    );
 
     const wireRectangleEvents = (rect: L.Rectangle) => {
       const report = () => onChangeRef.current(boundsToBBoxString(rect.getBounds()));

--- a/frontend/src/components/BoundingBoxMap.tsx
+++ b/frontend/src/components/BoundingBoxMap.tsx
@@ -81,9 +81,9 @@ function RectangleEditor({
       dragMode: true,
       removalMode: false,
     });
-    // Override the default toolbar tooltips and the shared "Finish" action label
-    // so each mode reads naturally for our use case. setLang supports custom
-    // language names but the TS types restrict to built-in locales, so we cast.
+    // Override the default toolbar button tooltips so each mode reads naturally.
+    // setLang supports custom language names but the TS types restrict to
+    // built-in locales, so we cast.
     (map.pm.setLang as unknown as (
       name: string,
       lang: Record<string, unknown>,
@@ -96,14 +96,41 @@ function RectangleEditor({
           editButton: 'Resize search area',
           dragButton: 'Move search area',
         },
-        actions: {
-          finish: 'Done',
-          cancel: 'Cancel',
-          finishMode: 'Done',
-        },
       },
       'en',
     );
+
+    // Per-mode "exit this mode" action button text. The built-in shared
+    // `actions.finish` would label all three modes the same, so we replace
+    // each control's actions with a custom one that has its own text and
+    // calls the matching disable function.
+    type ToolbarAction = { text: string; onClick: () => void; title?: string };
+    type ToolbarApi = {
+      changeActionsOfControl: (name: string, actions: ToolbarAction[]) => void;
+    };
+    const toolbar = map.pm.Toolbar as unknown as ToolbarApi;
+
+    toolbar.changeActionsOfControl('Rectangle', [
+      {
+        text: 'Done drawing',
+        title: 'Done drawing',
+        onClick: () => map.pm.disableDraw(),
+      },
+    ]);
+    toolbar.changeActionsOfControl('editMode', [
+      {
+        text: 'Done resizing',
+        title: 'Done resizing',
+        onClick: () => map.pm.disableGlobalEditMode(),
+      },
+    ]);
+    toolbar.changeActionsOfControl('dragMode', [
+      {
+        text: 'Done moving',
+        title: 'Done moving',
+        onClick: () => map.pm.disableGlobalDragMode(),
+      },
+    ]);
 
     const wireRectangleEvents = (rect: L.Rectangle) => {
       const report = () => onChangeRef.current(boundsToBBoxString(rect.getBounds()));

--- a/frontend/src/components/BoundingBoxMap.tsx
+++ b/frontend/src/components/BoundingBoxMap.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useRef } from 'react';
-import { MapContainer, TileLayer, Rectangle, useMap } from 'react-leaflet';
+import { MapContainer, TileLayer, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import '@geoman-io/leaflet-geoman-free';
+import '@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css';
 
 // Default Toronto box (matches the DB default for new subscriptions).
-const DEFAULT_BBOX = '43.640990267992834,-79.38644479872552,43.671784241717916,-79.38319149385921';
+const DEFAULT_BBOX =
+  '43.640990267992834,-79.38644479872552,43.671784241717916,-79.38319149385921';
 
 interface ParsedBBox {
   swLat: number;
@@ -21,7 +24,6 @@ function parseBBox(value: string | undefined | null): ParsedBBox {
   if (parts.some((n) => !Number.isFinite(n))) {
     return parseBBox(fallback);
   }
-  // Normalize: ensure first pair is the SW corner, second is NE.
   const [a, b, c, d] = parts;
   return {
     swLat: Math.min(a, c),
@@ -31,41 +33,97 @@ function parseBBox(value: string | undefined | null): ParsedBBox {
   };
 }
 
-function formatBBox(b: ParsedBBox): string {
-  return `${b.swLat},${b.swLng},${b.neLat},${b.neLng}`;
+function boundsToBBoxString(b: L.LatLngBounds): string {
+  return `${b.getSouth()},${b.getWest()},${b.getNorth()},${b.getEast()}`;
 }
 
-/**
- * Listens to the Leaflet map's move/zoom events and reports the
- * current viewport bounds as a "lat_sw,lng_sw,lat_ne,lng_ne" string.
- */
-function ViewportTracker({ onChange }: { onChange: (value: string) => void }) {
-  const map = useMap();
-  const lastReported = useRef<string>('');
+const RECT_STYLE: L.PathOptions = {
+  color: '#2563eb',
+  weight: 2,
+  fillOpacity: 0.08,
+};
 
+/**
+ * Renders a single editable rectangle on the map and exposes
+ * draw/edit/remove controls via leaflet-geoman.
+ *
+ * - The rectangle defines the search bounding box.
+ * - Drag corners to resize, drag the whole shape to move it.
+ * - Use the "Draw Rectangle" toolbar button to replace it with a new one.
+ * - The map itself can be panned/zoomed independently — the rectangle stays put.
+ */
+function RectangleEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const map = useMap();
+  const layerRef = useRef<L.Rectangle | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // Wire up geoman controls and the initial rectangle once when the map mounts.
   useEffect(() => {
-    const report = () => {
-      const b = map.getBounds();
-      const next = formatBBox({
-        swLat: b.getSouth(),
-        swLng: b.getWest(),
-        neLat: b.getNorth(),
-        neLng: b.getEast(),
-      });
-      if (next !== lastReported.current) {
-        lastReported.current = next;
-        onChange(next);
+    map.pm.addControls({
+      position: 'topright',
+      drawCircle: false,
+      drawCircleMarker: false,
+      drawMarker: false,
+      drawPolyline: false,
+      drawPolygon: false,
+      drawText: false,
+      drawRectangle: true,
+      cutPolygon: false,
+      rotateMode: false,
+      editMode: true,
+      dragMode: true,
+      removalMode: false,
+    });
+    map.pm.setLang('en');
+
+    const wireRectangleEvents = (rect: L.Rectangle) => {
+      const report = () => onChangeRef.current(boundsToBBoxString(rect.getBounds()));
+      rect.on('pm:edit', report);
+      rect.on('pm:dragend', report);
+    };
+
+    const initial = parseBBox(value);
+    const rect = L.rectangle(
+      [
+        [initial.swLat, initial.swLng],
+        [initial.neLat, initial.neLng],
+      ],
+      RECT_STYLE,
+    ).addTo(map);
+    layerRef.current = rect;
+    wireRectangleEvents(rect);
+
+    // When user draws a NEW rectangle from the toolbar, replace the existing one.
+    const handleCreate = (e: { layer: L.Layer; shape: string }) => {
+      if (e.shape !== 'Rectangle') return;
+      if (layerRef.current) map.removeLayer(layerRef.current);
+      const newRect = e.layer as L.Rectangle;
+      newRect.setStyle(RECT_STYLE);
+      layerRef.current = newRect;
+      wireRectangleEvents(newRect);
+      onChangeRef.current(boundsToBBoxString(newRect.getBounds()));
+    };
+    map.on('pm:create', handleCreate);
+
+    return () => {
+      map.off('pm:create', handleCreate);
+      map.pm.removeControls();
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
       }
     };
-    // Initial report once the map has settled.
-    map.whenReady(report);
-    map.on('moveend', report);
-    map.on('zoomend', report);
-    return () => {
-      map.off('moveend', report);
-      map.off('zoomend', report);
-    };
-  }, [map, onChange]);
+    // We deliberately ignore `value` changes after mount — the rectangle is
+    // the source of truth; we only seed it from the prop on first mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
 
   return null;
 }
@@ -77,6 +135,9 @@ interface BoundingBoxMapProps {
 
 export default function BoundingBoxMap({ value, onChange }: BoundingBoxMapProps) {
   const initial = useMemo(() => parseBBox(value), [value]);
+
+  // Centre the map on the initial rectangle, but with a bit of padding so the
+  // rectangle isn't flush with the edges of the viewport.
   const initialBounds = useMemo<L.LatLngBoundsExpression>(
     () => [
       [initial.swLat, initial.swLng],
@@ -85,20 +146,12 @@ export default function BoundingBoxMap({ value, onChange }: BoundingBoxMapProps)
     [initial],
   );
 
-  // Show a rectangle representing the saved value (kept in sync with `value`).
-  const currentBounds = useMemo<L.LatLngBoundsExpression>(() => {
-    const b = parseBBox(value);
-    return [
-      [b.swLat, b.swLng],
-      [b.neLat, b.neLng],
-    ];
-  }, [value]);
-
   return (
     <div>
-      <div className="h-72 w-full rounded-lg overflow-hidden border border-gray-300">
+      <div className="h-80 w-full rounded-lg overflow-hidden border border-gray-300">
         <MapContainer
           bounds={initialBounds}
+          boundsOptions={{ padding: [40, 40] }}
           scrollWheelZoom
           style={{ height: '100%', width: '100%' }}
         >
@@ -106,20 +159,13 @@ export default function BoundingBoxMap({ value, onChange }: BoundingBoxMapProps)
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
-          <Rectangle
-            bounds={currentBounds}
-            pathOptions={{
-              color: '#2563eb',
-              weight: 2,
-              fillOpacity: 0.05,
-            }}
-          />
-          <ViewportTracker onChange={onChange} />
+          <RectangleEditor value={value} onChange={onChange} />
         </MapContainer>
       </div>
       <p className="mt-2 text-xs text-gray-500 break-all font-mono">{value}</p>
       <p className="mt-1 text-xs text-gray-400">
-        Pan and zoom — the visible area defines the search bounding box.
+        Drag the rectangle's corners to resize, or drag the whole shape to move
+        it. Use the rectangle tool in the top-right to draw a new area.
       </p>
     </div>
   );

--- a/frontend/src/pages/SubscriptionFormPage.tsx
+++ b/frontend/src/pages/SubscriptionFormPage.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
+import BoundingBoxMap from '../components/BoundingBoxMap';
 import type { ExtraFilters, Subscription } from '../types';
 
 const BUILDING_TYPE_OPTIONS = ['apartment', 'townhouse', 'semi-detached', 'detached'];
 const RENTAL_TYPE_OPTIONS = ['whole'];
+
+const DEFAULT_BOUNDING_BOX =
+  '43.640990267992834,-79.38644479872552,43.671784241717916,-79.38319149385921';
 
 const DEFAULT_EXTRA: ExtraFilters = {
   floor: '[0,)',
@@ -25,6 +29,7 @@ interface FormState {
   email_frequency_hours: number;
   price_min: number;
   price_max: number;
+  bounding_box: string;
   building_types: string;
   rental_types: string;
   parkingSpaces: string;
@@ -78,6 +83,7 @@ export default function SubscriptionFormPage() {
     email_frequency_hours: 2,
     price_min: 0,
     price_max: 2100,
+    bounding_box: DEFAULT_BOUNDING_BOX,
     building_types: 'apartment',
     rental_types: 'whole',
     parkingSpaces: '',
@@ -123,6 +129,7 @@ export default function SubscriptionFormPage() {
           email_frequency_hours: s.email_frequency_hours,
           price_min: Number(s.price_min),
           price_max: Number(s.price_max),
+          bounding_box: s.bounding_box || DEFAULT_BOUNDING_BOX,
           building_types: s.building_types,
           rental_types: s.rental_types,
           parkingSpaces: ef.parkingSpaces ?? '',
@@ -165,6 +172,7 @@ export default function SubscriptionFormPage() {
       email_frequency_hours: Math.max(1, form.email_frequency_hours),
       price_min: form.price_min,
       price_max: form.price_max,
+      bounding_box: form.bounding_box,
       building_types: form.building_types,
       rental_types: form.rental_types,
       extra_filters: extraFilters,
@@ -194,7 +202,7 @@ export default function SubscriptionFormPage() {
   }
 
   return (
-    <div className="max-w-lg mx-auto">
+    <div className="max-w-2xl mx-auto">
       <h2 className="text-xl font-semibold text-gray-900 mb-6">
         {isEdit ? 'Edit Subscription' : 'New Subscription'}
       </h2>
@@ -267,6 +275,15 @@ export default function SubscriptionFormPage() {
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
             />
           </div>
+        </div>
+
+        {/* Bounding box (map) */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Search Area</label>
+          <BoundingBoxMap
+            value={form.bounding_box}
+            onChange={(v) => set('bounding_box', v)}
+          />
         </div>
 
         {/* Building types */}


### PR DESCRIPTION
## Summary
- Adds a Leaflet + OpenStreetMap map to the subscription detail form. The map's currently visible viewport (defined by the SW and NE corners of its diagonal) is captured as a `"lat_sw,lng_sw,lat_ne,lng_ne"` string and stored in the existing `bounding_box` column on `subscriptions`.
- Uses **OpenStreetMap** tiles via the standard public tile server — no API key, no signup, no cost.
- New `BoundingBoxMap` component (using `react-leaflet`):
  - Initialises from the saved `bounding_box` string (or the Toronto default for new subscriptions).
  - Listens for `moveend` and `zoomend` and updates the form value with the new viewport bounds.
  - Renders a subtle blue rectangle over the saved bounds for visual reference.
  - Shows the raw 4-tuple under the map for transparency / debugging.
- Form column widened from `max-w-lg` to `max-w-2xl` so the map has room to breathe.
- No DB migration needed — `bounding_box TEXT NOT NULL` already exists with a Toronto default.

## Format
`"lat_sw,lng_sw,lat_ne,lng_ne"` — same format the backend already passes to 51.ca's `boundaryBox` parameter, e.g.

```
43.640990267992834,-79.38644479872552,43.671784241717916,-79.38319149385921
```

## Test plan
- [ ] Open an existing subscription — map renders and zooms to the saved area
- [ ] Pan/zoom — the displayed `bounding_box` string updates live and matches the visible viewport
- [ ] Save — `subscriptions.bounding_box` reflects the new value in Supabase
- [ ] Create a new subscription — map opens to the default Toronto box, can be adjusted, saves correctly
- [ ] Backend polling still receives the updated `boundaryBox` on the next 51.ca call
