### PR TITLE
Show matched listings on the subscription detail screen

### DIFF
--- a/frontend/src/components/MatchedListings.tsx
+++ b/frontend/src/components/MatchedListings.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+interface MatchedListing {
+  id: number;
+  matched_at: string;
+  listing: {
+    title: string | null;
+    intersection: string | null;
+    slug: string | null;
+  } | null;
+}
+
+const LIMIT = 100;
+
+interface MatchedListingsProps {
+  subscriptionId: number;
+}
+
+export default function MatchedListings({ subscriptionId }: MatchedListingsProps) {
+  const [rows, setRows] = useState<MatchedListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    supabase
+      .from('subscription_listings')
+      .select('id, matched_at, listing:listings (title, intersection, slug)')
+      .eq('subscription_id', subscriptionId)
+      .order('matched_at', { ascending: false })
+      .limit(LIMIT)
+      .then(({ data, error: err }) => {
+        if (cancelled) return;
+        if (err) {
+          console.error('Failed to load matched listings:', err);
+          setError(err.message);
+          setLoading(false);
+          return;
+        }
+        setRows((data as unknown as MatchedListing[]) ?? []);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [subscriptionId]);
+
+  if (loading) {
+    return <p className="text-sm text-gray-400">Loading matched listings...</p>;
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 text-red-700 text-sm rounded-lg px-4 py-3">
+        Failed to load matched listings: {error}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-center py-10 bg-white rounded-xl border border-gray-200">
+        <p className="text-gray-500 text-sm">
+          No listings matched yet — they'll appear here as they come in.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <ul className="divide-y divide-gray-100">
+        {rows.map((row) => {
+          const listing = row.listing;
+          if (!listing) return null;
+          const href = listing.slug
+            ? `https://house.51.ca/rental/${listing.slug}`
+            : null;
+          const Inner = (
+            <div className="px-5 py-3">
+              <p className="text-sm font-medium text-gray-900 truncate">
+                {listing.title || 'Untitled listing'}
+              </p>
+              {listing.intersection && (
+                <p className="text-xs text-gray-500 mt-0.5 truncate">
+                  {listing.intersection}
+                </p>
+              )}
+            </div>
+          );
+          return (
+            <li key={row.id}>
+              {href ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block hover:bg-gray-50 transition"
+                >
+                  {Inner}
+                </a>
+              ) : (
+                <div className="opacity-60">{Inner}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      {rows.length === LIMIT && (
+        <p className="px-5 py-2 text-xs text-gray-400 border-t border-gray-100">
+          Showing the {LIMIT} most recent matches.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MatchedListings.tsx
+++ b/frontend/src/components/MatchedListings.tsx
@@ -70,9 +70,23 @@ export default function MatchedListings({ subscriptionId }: MatchedListingsProps
     );
   }
 
+  const formatDate = (iso: string) => {
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  };
+
   return (
-    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <ul className="divide-y divide-gray-100">
+    <div className="space-y-2">
+      <ul className="bg-white rounded-xl border border-gray-200 overflow-hidden divide-y divide-gray-100">
         {rows.map((row) => {
           const listing = row.listing;
           if (!listing) return null;
@@ -80,14 +94,37 @@ export default function MatchedListings({ subscriptionId }: MatchedListingsProps
             ? `https://house.51.ca/rental/${listing.slug}`
             : null;
           const Inner = (
-            <div className="px-5 py-3">
-              <p className="text-sm font-medium text-gray-900 truncate">
-                {listing.title || 'Untitled listing'}
-              </p>
-              {listing.intersection && (
-                <p className="text-xs text-gray-500 mt-0.5 truncate">
-                  {listing.intersection}
+            <div className="px-4 py-3 flex items-start gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-gray-900 line-clamp-2 break-words">
+                  {listing.title || 'Untitled listing'}
                 </p>
+                {listing.intersection && (
+                  <p className="text-xs text-gray-500 mt-1 truncate">
+                    {listing.intersection}
+                  </p>
+                )}
+                <p className="text-[11px] text-gray-400 mt-1">
+                  Matched {formatDate(row.matched_at)}
+                </p>
+              </div>
+              {href && (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-gray-300 shrink-0 mt-1"
+                >
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
               )}
             </div>
           );
@@ -98,7 +135,7 @@ export default function MatchedListings({ subscriptionId }: MatchedListingsProps
                   href={href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block hover:bg-gray-50 transition"
+                  className="block hover:bg-gray-50 active:bg-gray-100 transition"
                 >
                   {Inner}
                 </a>
@@ -110,7 +147,7 @@ export default function MatchedListings({ subscriptionId }: MatchedListingsProps
         })}
       </ul>
       {rows.length === LIMIT && (
-        <p className="px-5 py-2 text-xs text-gray-400 border-t border-gray-100">
+        <p className="text-xs text-gray-400 px-1">
           Showing the {LIMIT} most recent matches.
         </p>
       )}

--- a/frontend/src/components/SlideOver.tsx
+++ b/frontend/src/components/SlideOver.tsx
@@ -31,7 +31,7 @@ export default function SlideOver({ open, onClose, title, children }: SlideOverP
 
   return (
     <div
-      className={`fixed inset-0 z-50 ${open ? '' : 'pointer-events-none'}`}
+      className={`fixed inset-0 z-[1100] ${open ? '' : 'pointer-events-none'}`}
       aria-hidden={!open}
     >
       {/* backdrop */}

--- a/frontend/src/components/SlideOver.tsx
+++ b/frontend/src/components/SlideOver.tsx
@@ -1,0 +1,82 @@
+import { useEffect, type ReactNode } from 'react';
+
+interface SlideOverProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * A right-side slide-over drawer.
+ * - On mobile (<640px): full width.
+ * - On larger screens: fixed 480px wide.
+ * - Closes on ESC, on backdrop click, or via the close button.
+ * - Locks body scroll while open.
+ */
+export default function SlideOver({ open, onClose, title, children }: SlideOverProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 ${open ? '' : 'pointer-events-none'}`}
+      aria-hidden={!open}
+    >
+      {/* backdrop */}
+      <div
+        onClick={onClose}
+        className={`absolute inset-0 bg-black transition-opacity duration-300 ${
+          open ? 'opacity-30' : 'opacity-0'
+        }`}
+      />
+
+      {/* drawer */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className={`absolute top-0 right-0 h-full w-full sm:max-w-[480px] bg-white shadow-2xl flex flex-col transform transition-transform duration-300 ease-out ${
+          open ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4 sticky top-0 bg-white z-10">
+          <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-gray-400 hover:text-gray-700 transition w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-5 bg-gray-50">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SubscriptionFormPage.tsx
+++ b/frontend/src/pages/SubscriptionFormPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import BoundingBoxMap from '../components/BoundingBoxMap';
+import MatchedListings from '../components/MatchedListings';
 import type { ExtraFilters, Subscription } from '../types';
 
 const BUILDING_TYPE_OPTIONS = ['apartment', 'townhouse', 'semi-detached', 'detached'];
@@ -204,13 +205,26 @@ export default function SubscriptionFormPage() {
   return (
     <div className="max-w-2xl mx-auto">
       <h2 className="text-xl font-semibold text-gray-900 mb-6">
-        {isEdit ? 'Edit Subscription' : 'New Subscription'}
+        {isEdit ? form.name || 'Subscription' : 'New Subscription'}
       </h2>
 
       {error && (
         <div className="bg-red-50 text-red-700 text-sm rounded-lg px-4 py-3 mb-4">
           {error}
         </div>
+      )}
+
+      {isEdit && id && (
+        <section className="mb-8">
+          <h3 className="text-base font-semibold text-gray-900 mb-3">
+            Matched Listings
+          </h3>
+          <MatchedListings subscriptionId={Number(id)} />
+        </section>
+      )}
+
+      {isEdit && (
+        <h3 className="text-base font-semibold text-gray-900 mb-3">Settings</h3>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-5 bg-white rounded-xl border border-gray-200 p-6">

--- a/frontend/src/pages/SubscriptionFormPage.tsx
+++ b/frontend/src/pages/SubscriptionFormPage.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import BoundingBoxMap from '../components/BoundingBoxMap';
 import MatchedListings from '../components/MatchedListings';
+import SlideOver from '../components/SlideOver';
 import type { ExtraFilters, Subscription } from '../types';
 
 const BUILDING_TYPE_OPTIONS = ['apartment', 'townhouse', 'semi-detached', 'detached'];
@@ -96,6 +97,7 @@ export default function SubscriptionFormPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [pageLoading, setPageLoading] = useState(isEdit);
+  const [matchesOpen, setMatchesOpen] = useState(false);
 
   useEffect(() => {
     if (!isEdit) {
@@ -204,27 +206,44 @@ export default function SubscriptionFormPage() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <h2 className="text-xl font-semibold text-gray-900 mb-6">
-        {isEdit ? form.name || 'Subscription' : 'New Subscription'}
-      </h2>
+      <div className="flex items-start justify-between gap-3 mb-6">
+        <h2 className="text-xl font-semibold text-gray-900 truncate">
+          {isEdit ? form.name || 'Subscription' : 'New Subscription'}
+        </h2>
+        {isEdit && id && (
+          <button
+            type="button"
+            onClick={() => setMatchesOpen(true)}
+            className="shrink-0 inline-flex items-center gap-1.5 text-sm font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-lg px-3 py-2 transition whitespace-nowrap"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="8" y1="6" x2="21" y2="6" />
+              <line x1="8" y1="12" x2="21" y2="12" />
+              <line x1="8" y1="18" x2="21" y2="18" />
+              <line x1="3" y1="6" x2="3.01" y2="6" />
+              <line x1="3" y1="12" x2="3.01" y2="12" />
+              <line x1="3" y1="18" x2="3.01" y2="18" />
+            </svg>
+            <span className="hidden sm:inline">View Matches</span>
+            <span className="sm:hidden">Matches</span>
+          </button>
+        )}
+      </div>
 
       {error && (
         <div className="bg-red-50 text-red-700 text-sm rounded-lg px-4 py-3 mb-4">
           {error}
         </div>
-      )}
-
-      {isEdit && id && (
-        <section className="mb-8">
-          <h3 className="text-base font-semibold text-gray-900 mb-3">
-            Matched Listings
-          </h3>
-          <MatchedListings subscriptionId={Number(id)} />
-        </section>
-      )}
-
-      {isEdit && (
-        <h3 className="text-base font-semibold text-gray-900 mb-3">Settings</h3>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-5 bg-white rounded-xl border border-gray-200 p-6">
@@ -389,6 +408,16 @@ export default function SubscriptionFormPage() {
           </button>
         </div>
       </form>
+
+      {isEdit && id && (
+        <SlideOver
+          open={matchesOpen}
+          onClose={() => setMatchesOpen(false)}
+          title="Matched Listings"
+        >
+          <MatchedListings subscriptionId={Number(id)} />
+        </SlideOver>
+      )}
     </div>
   );
 }

--- a/migrations/005_listings_rls.sql
+++ b/migrations/005_listings_rls.sql
@@ -1,0 +1,42 @@
+-- Migration 005: RLS for subscription_listings and listings
+-- Run this in the Supabase SQL Editor.
+--
+-- Context:
+-- The frontend now joins subscription_listings with listings to display the
+-- matched listings on the subscription detail screen. Without RLS, an
+-- authenticated user could query any subscription's matched listings or any
+-- listing row. We restrict the join so users can only see rows tied to their
+-- own subscriptions; listings themselves are read-only public data (scraped
+-- from a public site) so we keep them readable to all authenticated users.
+
+-- ============================================================
+-- 1. subscription_listings: enable RLS, SELECT only own
+-- ============================================================
+
+ALTER TABLE subscription_listings ENABLE ROW LEVEL SECURITY;
+
+-- Users can read subscription_listings rows whose subscription belongs to them.
+CREATE POLICY subscription_listings_select_own ON subscription_listings
+    FOR SELECT USING (
+        subscription_id IN (
+            SELECT id FROM subscriptions
+            WHERE user_id = (SELECT id FROM users WHERE auth_id = auth.uid())
+        )
+    );
+
+-- No INSERT/UPDATE/DELETE policies for normal users; only the backend's
+-- service_role key writes to this table (service_role bypasses RLS).
+
+-- ============================================================
+-- 2. listings: enable RLS, SELECT open to authenticated users
+-- ============================================================
+
+ALTER TABLE listings ENABLE ROW LEVEL SECURITY;
+
+-- Listings are public information. Any logged-in user can read any listing.
+-- We don't grant access to anon to avoid exposing the table to unauthenticated
+-- traffic via the auto-generated REST API.
+CREATE POLICY listings_select_authenticated ON listings
+    FOR SELECT TO authenticated USING (TRUE);
+
+-- No write policies for normal users; only the backend's service_role inserts.


### PR DESCRIPTION
Closes #8

## Summary
- Subscription detail screen now lists all listings matched by the subscription, ordered newest → oldest. Each row shows the listing title + intersection and links to the original 51.ca posting in a new tab.
- New `MatchedListings` component joins `subscription_listings` with `listings` via Supabase's foreign-table select, sorted by `matched_at desc` (cap 100, with a small footer note when the cap is hit).
- `SubscriptionFormPage` redesigned: page header now uses the subscription's name (`Edit Subscription` was generic), the matched-listings section appears above the settings form, and the form is preceded by a `Settings` heading for context.
- Empty state ("No listings matched yet — they'll appear here as they come in.") shown when nothing's matched yet.
- Migration `005_listings_rls.sql` enables RLS on `subscription_listings` (users can only read rows tied to their own subscriptions) and on `listings` (any authenticated user can read; only the backend service role can write). The backend bypasses RLS via `service_role` as before.

## Migration step
Run `migrations/005_listings_rls.sql` in the Supabase SQL Editor before deploying.

## Test plan
- [ ] Run migration 005 in Supabase
- [ ] Open a subscription that has matched listings → see the list, newest first, with title + intersection
- [ ] Click a row → opens 51.ca posting in a new tab
- [ ] Open a subscription that has *no* matches → see the empty state
- [ ] Verify another user's subscription's matches are not visible (RLS)
- [ ] Backend polling still records matches into `subscription_listings` (service_role bypasses RLS)
- [ ] Backend email service still works (it queries via the same service_role)